### PR TITLE
Fixed addProductToCart function, added array and catch

### DIFF
--- a/src/js/product.js
+++ b/src/js/product.js
@@ -1,9 +1,17 @@
 import { setLocalStorage } from "./utils.mjs";
 import { findProductById } from "./productData.mjs";
 
+// Add product to the cart
 function addProductToCart(product) {
-  setLocalStorage("so-cart", product);
+  let cart = JSON.parse(localStorage.getItem("so-cart"));
+  // Ensure the cart is an array
+  if (!Array.isArray(cart)) {
+    cart = [];
+  }
+  cart.push(product);
+  setLocalStorage("so-cart", cart);
 }
+
 // add to cart button event handler
 async function addToCartHandler(e) {
   const product = await findProductById(e.target.dataset.id);


### PR DESCRIPTION
I found that the error is being caused because the addProductToCart button was overwriting the localStorage instead of added additional items to an array.