### PR TITLE
Sc--add-to-cart-broken Issue Resolved

### DIFF
--- a/src/js/utils.mjs
+++ b/src/js/utils.mjs
@@ -11,7 +11,9 @@ export function getLocalStorage(key) {
 }
 // save data to local storage
 export function setLocalStorage(key, data) {
-  localStorage.setItem(key, JSON.stringify(data));
+  let currentCart = JSON.parse(localStorage.getItem(key)) || [];
+  currentCart.push(data);
+  localStorage.setItem(key, JSON.stringify(currentCart));
 }
 // set a listener for both touchend and click
 export function setClick(selector, callback) {


### PR DESCRIPTION
Found that the setLocalStorage function would override what was in the cart, limiting it to one item.

Resolved by pulling the current localStorage or simply creating empty brackets if there is no current data, then pushing it back with the added item.