### PR TITLE
Fixed empty cart error in cart.js

### DIFF
--- a/src/js/cart.js
+++ b/src/js/cart.js
@@ -1,9 +1,22 @@
 import { getLocalStorage } from "./utils.mjs";
 
 function renderCartContents() {
-  const cartItems = getLocalStorage("so-cart");
-  const htmlItems = cartItems.map((item) => cartItemTemplate(item));
-  document.querySelector(".product-list").innerHTML = htmlItems.join("");
+  try {
+    const cartItems = getLocalStorage("so-cart");
+
+    // Check if the cart is empty
+    if (!cartItems || cartItems.length === 0) {
+      document.querySelector(".product-list").innerHTML = "<p>Your cart is empty.</p>";
+      return;
+    }
+
+    // Render the cart items if they exist
+    const htmlItems = cartItems.map((item) => cartItemTemplate(item));
+    document.querySelector(".product-list").innerHTML = htmlItems.join("");
+  } catch (error) {
+    console.error("Error rendering cart contents:", error);
+    document.querySelector(".product-list").innerHTML = "<p>There was an error loading your cart.</p>";
+  }
 }
 
 function cartItemTemplate(item) {


### PR DESCRIPTION
The error in cart.html was being caused because it was trying to create an item out of an empty object.  I added a try catch with some error handling to ensure the `renderCartContents()` only calls `cartItemTemplate` if there are items in localStorage.